### PR TITLE
added swaggerConfigUrl

### DIFF
--- a/packages/app/public/swagger-config.yaml
+++ b/packages/app/public/swagger-config.yaml
@@ -1,0 +1,19 @@
+##############################################################################
+#                                                                            #
+# This configuration file is set in your `app-config.local` with:            #
+# glooPlatformPortal:                                                        #
+#   swaggerConfigUrl: /swagger-config.yaml                                   #
+#                                                                            #
+# - This file can be JSON or YAML.                                           #
+# - The URL can be specified with a relative or absolute path.               #
+#                                                                            #
+# For configuration options, see:                                            #
+# https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/  #
+#                                                                            #
+##############################################################################
+
+# docExpansion: String=["list"*, "full", "none"].
+#   Controls the default expansion setting for the operations and tags.
+#   It can be 'list' (expands only the tags), 'full' (expands the tags and operations)
+#   or 'none' (expands nothing).
+docExpansion: list

--- a/plugins/platform-portal-backstage-plugin-frontend/README.md
+++ b/plugins/platform-portal-backstage-plugin-frontend/README.md
@@ -92,6 +92,15 @@ The following sections provide quick steps for testing this plugin.
 
      # The `end_session_endpoint` is where to end the session.
      logoutEndpoint: ''
+
+     # This is an optional URL for your Swagger configuration file.
+     # The URL can be an absolute or relative path, and can be a JSON or YAML file.
+     # If you would like to configure the Swagger UI using the [Swagger UI configuration options](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/), you can do this by:
+     #   1. setting this variable to `"/swagger-config.yaml"`,
+     #   2. editing the `/packages/app/public/swagger-config.yaml` file,
+     #   3. verifying your changes locally,
+     #   4. rebuilding the project.
+     swaggerConfigUrl: ''
    ```
 
 > &#x26a0;&#xfe0f; For Keycloak users, make sure the OIDC type is set to "public access type" on your client's settings page. On newer Keycloak versions, this is done by unchecking the "Client authentication" checkbox. Older Keycloak versions have an "Access Type" dropdown that should be set to public access.

--- a/plugins/platform-portal-backstage-plugin-frontend/config.d.ts
+++ b/plugins/platform-portal-backstage-plugin-frontend/config.d.ts
@@ -6,6 +6,11 @@ export interface Config {
     portalServerUrl: string;
 
     /**
+     * @visibility frontend
+     */
+    swaggerConfigUrl: string;
+
+    /**
      * The oauth client id.
      * In keycloak, this is shown in the client settings
      * of your keycloak instances UI: <your-keycloak-url>/auth

--- a/plugins/platform-portal-backstage-plugin-frontend/src/components/ApiDetailsPage/ApiSchemaDisplay/SwaggerDisplay.tsx
+++ b/plugins/platform-portal-backstage-plugin-frontend/src/components/ApiDetailsPage/ApiSchemaDisplay/SwaggerDisplay.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import SwaggerUIConstructor from 'swagger-ui';
 import 'swagger-ui/dist/swagger-ui.css';
 import { APISchema } from '../../../Apis/api-types';
+import { useGetSwaggerConfigUrl } from '../../../configHooks';
 
 const sanitize = (id: string) => id.replaceAll('.', '-');
 
@@ -12,6 +13,8 @@ export function SwaggerDisplay({
   spec: APISchema | undefined;
   apiId: string;
 }) {
+  const swaggerConfigUrl = useGetSwaggerConfigUrl();
+
   // The sanitized dom_id, where all periods are replaced with dashes. This fixes issues where Swagger tries
   // doing a `querySelector` which fails, due to it treating the period as a class selector, and not part of the ID itself.
   const [sanitizedDomId, setSanitizedDomId] = useState<string>(sanitize(apiId));
@@ -34,9 +37,9 @@ export function SwaggerDisplay({
       dom_id: `#display-swagger-${sanitizedDomId}`,
       withCredentials: true,
       deepLinking: true,
-      syntaxHighlight: { activate: false },
+      configUrl: swaggerConfigUrl !== '' ? swaggerConfigUrl : undefined,
     });
-  }, [sanitizedDomId, spec]);
+  }, [sanitizedDomId, spec, swaggerConfigUrl]);
 
   return (
     <div

--- a/plugins/platform-portal-backstage-plugin-frontend/src/configHooks.ts
+++ b/plugins/platform-portal-backstage-plugin-frontend/src/configHooks.ts
@@ -9,6 +9,15 @@ export const useGetPortalServerUrl = () => {
   return value ?? 'http://localhost:31080/v1';
 };
 
+export const useGetSwaggerConfigUrl = () => {
+  const config = useApi(configApiRef);
+  let value = config.getOptionalString('glooPlatformPortal.swaggerConfigUrl');
+  // Remove trailing slash if supplied.
+  if (!!value && value.at(-1) === '/')
+    value = value.substring(0, value.length - 1);
+  return value ?? '';
+};
+
 export const useGetClientId = () => {
   const config = useApi(configApiRef);
   const value = config.getOptionalString('glooPlatformPortal.clientId');


### PR DESCRIPTION
This is related to https://github.com/solo-io/dev-portal/issues/2865, and adds a `swaggerConfigUrl` property to the `app-config.local`.